### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/better-salmon/form/security/code-scanning/1](https://github.com/better-salmon/form/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not appear to require write access to the repository, we can set the permissions to `contents: read`, which is the minimal privilege required for most workflows. This change should be applied at the root level of the workflow to ensure it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
